### PR TITLE
i think its good

### DIFF
--- a/cmd/net-helper/commands.go
+++ b/cmd/net-helper/commands.go
@@ -62,34 +62,6 @@ var AddCpCmd cli.Command = cli.Command{
 	CustomHelpTemplate:     "",
 }
 
-// AddCpRCmd - Cli Command that invokes AddCommitPushRemote git function
-var AddCpRCmd cli.Command = cli.Command{
-	Name:        "addCommitPushRemote",
-	Aliases:     []string{"acpr"},
-	Usage:       "gg acpr [commit_msg]",
-	UsageText:   "add -> commit -> push -> set upstream in one command",
-	Description: "automates remote push of changes in fresh branch",
-	ArgsUsage:   "",
-	Category:    "",
-	BashComplete: func(c *cli.Context) {
-		fmt.Fprintf(c.App.Writer, "--better\n")
-	},
-	OnUsageError: func(c *cli.Context, err error, isSubcommand bool) error {
-		fmt.Fprintf(c.App.Writer, "for shame\n")
-		return err
-	},
-	Action:                 AddCommitPushRemote,
-	Subcommands:            []*cli.Command{},
-	Flags:                  []cli.Flag{},
-	SkipFlagParsing:        false,
-	HideHelp:               false,
-	HideHelpCommand:        false,
-	Hidden:                 false,
-	UseShortOptionHandling: false,
-	HelpName:               "",
-	CustomHelpTemplate:     "",
-}
-
 // StashPpCmd - Cli Command that invokes StashPullPop git function
 var StashPpCmd cli.Command = cli.Command{
 	Name:        "stashPullPop",

--- a/cmd/net-helper/gitfuncs.go
+++ b/cmd/net-helper/gitfuncs.go
@@ -107,7 +107,7 @@ func Fullpull(c *cli.Context) error {
 // AddCommitPush - Add, Commit, Push local changes to current branch
 func AddCommitPush(c *cli.Context) error {
 	commitMsg := os.Args[2]
-	cmds := GitCmdList{
+	existPushCommands := GitCmdList{
 		GitCmd{
 			cmd:  "add",
 			args: []string{"."},
@@ -122,20 +122,7 @@ func AddCommitPush(c *cli.Context) error {
 		},
 	}
 
-	info, err := cmds.multipass()
-	if err != nil {
-		return err
-	}
-	fmt.Println(info)
-
-	return nil
-}
-
-// AddCommitPushRemote - Add, Commit, Push local changes
-// on fresh branch (sets upstream)
-func AddCommitPushRemote(c *cli.Context) error {
-	commitMsg := os.Args[2]
-	cmds := GitCmdList{
+	freshPushCommands := GitCmdList{
 		GitCmd{
 			cmd:  "add",
 			args: []string{"."},
@@ -150,6 +137,19 @@ func AddCommitPushRemote(c *cli.Context) error {
 		},
 	}
 
+	br, err := getGitBranch()
+	branchExists, err := checkBranchExists(br)
+	if err != nil {
+		panic(err)
+	}
+
+	var cmds GitCmdList
+	if branchExists {
+		cmds = existPushCommands
+	} else {
+		cmds = freshPushCommands
+	}
+
 	info, err := cmds.multipass()
 	if err != nil {
 		return err
@@ -157,6 +157,10 @@ func AddCommitPushRemote(c *cli.Context) error {
 	fmt.Println(info)
 
 	return nil
+}
+
+func checkBranchExists(branch string) (bool, error) {
+	return false, nil
 }
 
 // StashPullPop - Runs git stash, pull, pop

--- a/cmd/net-helper/golee.go
+++ b/cmd/net-helper/golee.go
@@ -24,7 +24,6 @@ func main() {
 		Commands: []*cli.Command{
 			&FullPullCmd,
 			&AddCpCmd,
-			&AddCpRCmd,
 			&StashPpCmd,
 			&SoftResetCmd,
 			&HardResetCmd,


### PR DESCRIPTION
This change removes the need to have two separate calls to handle adding, committing, pushing for both new and existing branches. Calling `golee acp '<commit_message>'` will now handle both new and existing branches